### PR TITLE
Automated Microsoft Word Builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.docx
+*.zip
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ deploy:
     branch: master
     tags: true
 language: ruby
-script: bundle exec rake
+before_deploy: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,8 @@
 ---
-# Commands to run before building
 before_script:
-  # Install cabal, the package manager for programs like pandoc that are
-  # written in the Haskell language.
-  - sudo apt-get install cabal-install
-  # Install the zip archiver.
-  - sudo apt-get install zip
-  # Update cabal's list of available packages.
-  - cabal update
-  # Install pandoc
-  - cabal install pandoc
-  # Add the directory where pandoc will be installed to the list of
-  # directories the operating system will search.
-  - export PATH=$HOME/.cabal/bin:$PATH
+  - sudo apt-get update
+  - sudo apt-get install -y pandoc zip
 
-# Upload SeriesSeed.zip as a GitHub release for every tagged commit.
 deploy:
   provider: releases
   api_key:
@@ -25,6 +13,5 @@ deploy:
     repo: kemitchell/equity
     tags: true
 
-# Use rake to build SeriesSeed.zip
 language: ruby
-script: rake
+script: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ deploy:
   provider: releases
   api_key:
     secure: kMooLRcmw6nKoJGncvNl11c32uZoZQxHdvsL7VPAkkaK3x5bhzbG/1m5gYLp6IcAPjyqEtRiENcaER3YshN2uEqUS+z8YNFH+rLe3Uy/T4ySJ0R2i70YhobHFirQyY/BMKmx9lMIc/2AY7z4fj2xqm4RxVpQvXVhPI35d0tfuqA=
-  file: SeriesSeed.zip
+  file: "Series Seed - Microsoft Word.zip"
   skip_cleanup: true
   on:
     repo: kemitchell/equity

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ deploy:
   skip_cleanup: true
   on:
     repo: kemitchell/equity
+    branch: master
     tags: true
 
 language: ruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+---
+# Commands to run before building
+before_script:
+  # Install cabal, the package manager for programs like pandoc that are
+  # written in the Haskell language.
+  - sudo apt-get install cabal-install
+  # Install the zip archiver.
+  - sudo apt-get install zip
+  # Update cabal's list of available packages.
+  - cabal update
+  # Install pandoc
+  - cabal install pandoc
+  # Add the directory where pandoc will be installed to the list of
+  # directories the operating system will search.
+  - export PATH=$HOME/.cabal/bin:$PATH
+
+# Upload SeriesSeed.zip as a GitHub release for every tagged commit.
+deploy:
+  provider: releases
+  api_key:
+    secure: OboOkvnsBsGZFXg4ZjUdQqgLahn3it/Pj1jWoTbeEYy26AhAt/iljTRfmJt1LJ2RtzqlNxt6+m1M/wVthExKUnBCWu6gX+XqYt3MiZPl5SjwKNuo5kAM43/XPEMsGVL15CIHH9JKQ4Awo05OH9jGv1DVVeGGg3WH2vEVuKYfqzw=
+  file: SeriesSeed.zip
+  skip_cleanup: true
+  on:
+    repo: kemitchell/equity
+    tags: true
+
+# Use rake to build SeriesSeed.zip
+language: ruby
+script: rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ deploy:
   provider: releases
   api_key:
     secure: kMooLRcmw6nKoJGncvNl11c32uZoZQxHdvsL7VPAkkaK3x5bhzbG/1m5gYLp6IcAPjyqEtRiENcaER3YshN2uEqUS+z8YNFH+rLe3Uy/T4ySJ0R2i70YhobHFirQyY/BMKmx9lMIc/2AY7z4fj2xqm4RxVpQvXVhPI35d0tfuqA=
-  file: "Series Seed - Microsoft Word.zip"
+  file: "Series-Seed-Microsoft-Word.zip"
   skip_cleanup: true
   on:
     repo: kemitchell/equity

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,15 @@
----
 before_script:
-  - sudo apt-get update
-  - sudo apt-get install -y pandoc zip
-
+- sudo apt-get update
+- sudo apt-get install -y pandoc zip
 deploy:
   provider: releases
   api_key:
-    secure: OboOkvnsBsGZFXg4ZjUdQqgLahn3it/Pj1jWoTbeEYy26AhAt/iljTRfmJt1LJ2RtzqlNxt6+m1M/wVthExKUnBCWu6gX+XqYt3MiZPl5SjwKNuo5kAM43/XPEMsGVL15CIHH9JKQ4Awo05OH9jGv1DVVeGGg3WH2vEVuKYfqzw=
+    secure: kMooLRcmw6nKoJGncvNl11c32uZoZQxHdvsL7VPAkkaK3x5bhzbG/1m5gYLp6IcAPjyqEtRiENcaER3YshN2uEqUS+z8YNFH+rLe3Uy/T4ySJ0R2i70YhobHFirQyY/BMKmx9lMIc/2AY7z4fj2xqm4RxVpQvXVhPI35d0tfuqA=
   file: SeriesSeed.zip
   skip_cleanup: true
   on:
     repo: kemitchell/equity
     branch: master
     tags: true
-
 language: ruby
 script: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+group :test do
+  gem 'rake'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ task zip => docx_files do |t|
 end
 
 rule '.docx' => '.md' do |t|
-  sh "pandoc -o '#{t.name}' '#{t.source}'"
+  sh "pandoc --smart -o '#{t.name}' '#{t.source}'"
 end
 
 CLEAN.include(docx_files)

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,21 @@
+require 'rake'
+require 'rake/clean'
+
+markdown_files = Rake::FileList['Series Seed*.md']
+docx_files = markdown_files.ext('docx')
+readmes = Rake::FileList['README.md', 'RELEASENOTES.md']
+zip = 'SeriesSeed.zip'
+
+task :default => zip
+
+task zip => docx_files + readmes do |t|
+  sh "zip '#{t.name}' " + t.prerequisites.map { |file| "'#{file}'" }.join(' ')
+end
+
+rule '.docx' => '.md' do |t|
+  sh "pandoc -o '#{t.name}' '#{t.source}'"
+end
+
+CLEAN.include(docx_files)
+
+CLOBBER << zip

--- a/Rakefile
+++ b/Rakefile
@@ -1,14 +1,13 @@
 require 'rake'
 require 'rake/clean'
 
-markdown_files = Rake::FileList['Series Seed*.md']
+markdown_files = Rake::FileList['*.md']
 docx_files = markdown_files.ext('docx')
-readmes = Rake::FileList['README.md', 'RELEASENOTES.md']
-zip = 'SeriesSeed.zip'
+zip = 'Series Seed - Microsoft Word.zip'
 
 task :default => zip
 
-task zip => docx_files + readmes do |t|
+task zip => docx_files do |t|
   sh "zip '#{t.name}' " + t.prerequisites.map { |file| "'#{file}'" }.join(' ')
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require 'rake/clean'
 
 markdown_files = Rake::FileList['*.md']
 docx_files = markdown_files.ext('docx')
-zip = 'Series Seed - Microsoft Word.zip'
+zip = 'Series-Seed-Microsoft-Word.zip'
 
 task :default => zip
 


### PR DESCRIPTION
This pull request adds build configuration files for generating and publishing ZIP archives of .docx Word files automatically on each tagged release of Series Seed. It addresses some concerns raised in issue #24.

You can see an example of a release and a generated ZIP [on the releases page of my fork](https://github.com/kemitchell/equity/releases).

For reasons explained below, someone should [add me as a member of the seriesseed GitHub organization](https://github.com/orgs/seriesseed/invitations/new) so that I can set up automated building and merge this PR myself. I will update the configuration files to work for the official repository, rather than my fork, and squash all the commits together so we don't have five just for build automation.

[Travis CI](https://travis-ci.org/) is a free service (for open-source projects) that does automatic testing and building of projects hosted on GitHub. The new configuration files have Travis use [pandoc](http://pandoc.org) to convert all the Markdown files in the repository to .docx, then ZIP them up and add them as a download to a GitHub release. As a member of the GitHub organization, I can enable Travis CI for seriesseed/equity and set up the right secure API access tokens for publishing build files back to GitHub. I will also go ahead and tag old numbered releases in the repository.

Generated ZIPs will not include .docx redlines, but tagging releases on GitHub will make it very easy to link to a comparison of past numbered versions. It will also make it possible to download ZIPs of each historical version of Series Seed from one page, in case someone does want to run a redline of specific versions.

If there's deep interest, we may also look into providing a different default .docx template than the one pandoc uses by default. The styles in the default seem to be the old Word 2010 defaults, with blue headings &c. They're not "lawyerly", but they're very easy to change.
